### PR TITLE
Replace local image paths with placeholders

### DIFF
--- a/frontend/src/components/ui/hero.tsx
+++ b/frontend/src/components/ui/hero.tsx
@@ -31,7 +31,7 @@ const Hero = () => {
               {/* Main Cart Image */}
               <div className="absolute right-0 top-1/2 -translate-y-1/2">
                 <Image
-                  src="/images/shopping-cart.png"
+                  src="https://placehold.co/400x400?text=Cart"
                   alt="Shopping Cart"
                   width={400}
                   height={400}
@@ -42,7 +42,7 @@ const Hero = () => {
               {/* Floating Elements */}
               <div className="absolute left-10 top-10 rounded-full bg-teal-100 p-4">
                 <Image
-                  src="/images/avatar-placeholder.jpg"
+                  src="https://placehold.co/64x64?text=U"
                   alt="User Avatar"
                   width={64}
                   height={64}

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -9,28 +9,28 @@ const products = {
       title: 'Product title',
       price: 230,
       rating: 4,
-      imageUrl: '/images/orange.jpg',
+      imageUrl: 'https://placehold.co/600x600?text=Product+1',
       itemsSold: 360,
     },
     {
       title: 'Product title',
       price: 230,
       rating: 4,
-      imageUrl: '/images/cherries.jpg',
+      imageUrl: 'https://placehold.co/600x600?text=Product+2',
       itemsSold: 360,
     },
     {
       title: 'Product title',
       price: 230,
       rating: 4,
-      imageUrl: '/images/avocado.jpg',
+      imageUrl: 'https://placehold.co/600x600?text=Product+3',
       itemsSold: 360,
     },
     {
       title: 'Product title',
       price: 230,
       rating: 4,
-      imageUrl: '/images/strawberry.jpg',
+      imageUrl: 'https://placehold.co/600x600?text=Product+4',
       itemsSold: 360,
     },
   ],
@@ -39,28 +39,28 @@ const products = {
       title: 'Product title',
       price: 230,
       rating: 4,
-      imageUrl: '/images/orange-vase.jpg',
+      imageUrl: 'https://placehold.co/600x600?text=Product+5',
       itemsSold: 360,
     },
     {
       title: 'Product title',
       price: 230,
       rating: 4,
-      imageUrl: '/images/orange-stand.jpg',
+      imageUrl: 'https://placehold.co/600x600?text=Product+6',
       itemsSold: 360,
     },
     {
       title: 'Product title',
       price: 230,
       rating: 4,
-      imageUrl: '/images/flower-vase.jpg',
+      imageUrl: 'https://placehold.co/600x600?text=Product+7',
       itemsSold: 360,
     },
     {
       title: 'Product title',
       price: 230,
       rating: 4,
-      imageUrl: '/images/coral.jpg',
+      imageUrl: 'https://placehold.co/600x600?text=Product+8',
       itemsSold: 360,
     },
   ],
@@ -126,7 +126,7 @@ export default function Home() {
           <div className="container mx-auto px-4 text-center">
             <div className="mx-auto max-w-md">
               <img
-                src="/images/logo.png"
+                src="https://placehold.co/100x32?text=Logo"
                 alt="Logo"
                 className="mx-auto mb-8 h-8"
               />


### PR DESCRIPTION
## Summary
- swap hero images for remote placeholders
- use placeholder logo image
- update product demo images to remote placeholders

## Testing
- `npm run build` in `frontend` *(fails: next not found)*
- `npm run test` in `backend` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_684084188e5c832c8b68c2b7c9b30896